### PR TITLE
docs: Fix links to repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/NodeSecure/i18n.git"
+    "url": "git+https://github.com/NodeSecure/flags.git"
   },
   "keywords": [
     "nodesecure",
@@ -34,9 +34,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/NodeSecure/i18n/issues"
+    "url": "https://github.com/NodeSecure/flags/issues"
   },
-  "homepage": "https://github.com/NodeSecure/i18n#readme",
+  "homepage": "https://github.com/NodeSecure/flags#readme",
   "devDependencies": {
     "@nodesecure/eslint-config": "^1.3.0",
     "@slimio/is": "^1.5.1",


### PR DESCRIPTION
Hey!
I noticed that links to the project are incorrect (probably were copied from another project).
It misleads when trying to go to the repository from [the npm page](https://www.npmjs.com/package/@nodesecure/flags).

He is a screenshot how it looks: 
<img width="1301" alt="Screen Shot 2021-11-28 at 17 54 46" src="https://user-images.githubusercontent.com/16868922/143774935-ff7975e8-ab39-4b79-8fa6-9e71aadc0c87.png">

